### PR TITLE
update repo URL (moved to rust-embedded-community)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The Minimum Supported Rust Version (MSRV) has been defined as 1.60.0 and is being enforced in `Cargo.toml`
 
 <!-- next-url -->
-[Unreleased]: https://github.com/rursprung/adafruit-bluefruit-protocol-rs/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/rursprung/adafruit-bluefruit-protocol-rs/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/rursprung/adafruit-bluefruit-protocol-rs/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.62"
 
 description = "A `no_std` parser for the Adafruit Bluefruit LE Connect controller protocol."
-repository = "https://github.com/rursprung/adafruit-bluefruit-protocol-rs"
+repository = "https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs"
 categories = ["embedded", "hardware-support", "no-std", "no-std::no-alloc"]
 keywords = ["adafruit", "bluefruit", "bluetooth", "protocol"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Adafruit Bluefruit LE Connect Controller Protocol Parser
-[![CI](https://github.com/rursprung/adafruit-bluefruit-protocol-rs/actions/workflows/CI.yml/badge.svg)](https://github.com/rursprung/adafruit-bluefruit-protocol-rs/actions/workflows/CI.yml)
+[![CI](https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/actions/workflows/CI.yml/badge.svg)](https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/adafruit-bluefruit-protocol)](https://crates.io/crates/adafruit-bluefruit-protocol)
 ![Licenses](https://img.shields.io/crates/l/adafruit-bluefruit-protocol)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)

--- a/release.toml
+++ b/release.toml
@@ -3,5 +3,5 @@ pre-release-replacements = [
     {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
     {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
     {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly=1},
-    {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/rursprung/adafruit-bluefruit-protocol-rs/compare/{{tag_name}}...HEAD", exactly=1},
+    {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs/compare/{{tag_name}}...HEAD", exactly=1},
 ]


### PR DESCRIPTION
the repository has found a new home in the [rust-embedded-community]! this will reduce the bus factor in the future.

as the repo has been moved all issues, PRs, etc. have been kept, ensuring that they can be found again in the future.

[rust-embedded-community]: https://github.com/rust-embedded-community