### PR TITLE
prepare v0.3.0: implement `core::error::Error`, rename `use_..` features & add some `Copy`, `Clone`, `Hash` where applicable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.62.0, stable]
+        rust: [1.81.0, stable]
         features: ['use_alloc', 'use_alloc,defmt', 'use_heapless', 'use_heapless,defmt']
         exclude:
-          - rust: 1.62.0
+          - rust: 1.81.0
             features: 'use_alloc,defmt'
-          - rust: 1.62.0
+          - rust: 1.81.0
             features: 'use_heapless,defmt'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,3 +87,17 @@ jobs:
         with:
           sarif_file: examples/stm32f4-event-printer/rust-clippy-results.sarif
           wait-for-processing: true
+
+  # simplify GH settings: have one single build to be required
+  build-results:
+    name: Final Results
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [lib, stm32f4-event-printer]
+    steps:
+      - name: check for failed builds of the library
+        if: ${{ needs.lib.result != 'success' }}
+        run: exit 1
+      - name: check for failed builds of the example
+        if: ${{ needs.stm32f4-event-printer.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         rust: [1.81.0, stable]
-        features: ['use_alloc', 'use_alloc,defmt', 'use_heapless', 'use_heapless,defmt']
+        features: ['alloc', 'alloc,defmt', 'heapless', 'heapless,defmt']
         exclude:
           - rust: 1.81.0
-            features: 'use_alloc,defmt'
+            features: 'alloc,defmt'
           - rust: 1.81.0
-            features: 'use_heapless,defmt'
+            features: 'heapless,defmt'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+* The MSRV has been updated to 1.81.0 due to `core::error::Error` being implemented
 
 ## [0.2.0] - 2023-11-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+* `Copy`, `Clone` and `Hash` on error & event types (where possible)
 ### Changed
 * The MSRV has been updated to 1.81.0 due to `core::error::Error` being implemented
 * **BREAKING**: the features `use_alloc` and `use_heapless` have been renamed to `alloc` and `heapless` respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Changed
 * The MSRV has been updated to 1.81.0 due to `core::error::Error` being implemented
+* **BREAKING**: the features `use_alloc` and `use_heapless` have been renamed to `alloc` and `heapless` respectively.
 
 ## [0.2.0] - 2023-11-14
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adafruit-bluefruit-protocol"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.81"
 
 description = "A `no_std` parser for the Adafruit Bluefruit LE Connect controller protocol."
 repository = "https://github.com/rust-embedded-community/adafruit-bluefruit-protocol-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [features]
 default = ["accelerometer_event", "button_event", "color_event", "gyro_event", "location_event", "magnetometer_event", "quaternion_event"]
 
-use_heapless = ["dep:heapless"]
-use_alloc = []
+heapless = ["dep:heapless"]
+alloc = []
 
 defmt = ["dep:defmt", "heapless?/defmt-03"]
 

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ A simple example for the STM32F4 microcontrollers is [available](examples/stm32f
 For the changelog please see the dedicated [CHANGELOG.md](CHANGELOG.md).
 
 ## Minimum Supported Rust Version (MSRV)
-This crate is guaranteed to compile on stable Rust 1.62 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.81 and up. It *might*
 compile with older versions but that may change in any new patch release.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Note that this work is not affiliated with Adafruit.
 
 ## Mandatory Features
 This crate is `no_std` and you can choose whether you want to use
-[`heapless::Vec`](https://docs.rs/heapless/0.8.0/heapless/struct.Vec.html) by selecting the feature `use_heapless` or
-[`alloc::vec::Vec`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html) by selecting the feature `use_alloc`.
+[`heapless::Vec`](https://docs.rs/heapless/0.8.0/heapless/struct.Vec.html) by selecting the feature `heapless` or
+[`alloc::vec::Vec`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html) by selecting the feature `alloc`.
 If you select neither or both you'll get a compile error.
 
 ## Optional Features

--- a/examples/stm32f4-event-printer/Cargo.toml
+++ b/examples/stm32f4-event-printer/Cargo.toml
@@ -17,7 +17,7 @@ defmt = "0.3.6"
 defmt-rtt = "0.4"
 
 # use `adafruit-bluefruit-protocol = "0.1"` in reality; path used here to ensure that the example always compiles against the latest master
-adafruit-bluefruit-protocol = { path = "../..", features = ["defmt", "use_heapless"] }
+adafruit-bluefruit-protocol = { path = "../..", features = ["defmt", "heapless"] }
 
 [profile.release]
 codegen-units = 1

--- a/src/accelerometer_event.rs
+++ b/src/accelerometer_event.rs
@@ -3,7 +3,7 @@
 use super::{try_f32_from_le_bytes, ProtocolParseError};
 
 /// Represents an accelerometer event from the protocol.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough

--- a/src/button_event.rs
+++ b/src/button_event.rs
@@ -1,6 +1,8 @@
 //! Implements the [`ButtonEvent`] and its parsing from the protocol.
 
 use super::ProtocolParseError;
+use core::error::Error;
+use core::fmt::{Display, Formatter};
 
 /// Errors which can be raised while parsing a button event.
 #[derive(PartialEq, Eq, Debug)]
@@ -11,6 +13,18 @@ pub enum ButtonParseError {
     /// The message contained an unknown button state. For the known button states see [`ButtonState`].
     UnknownButtonState(u8),
 }
+
+impl Display for ButtonParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        use ButtonParseError::*;
+        match self {
+            UnknownButton(button) => write!(f, "Unknown button: {:#x}", button),
+            UnknownButtonState(state) => write!(f, "Unknown button state: {:#x}", state),
+        }
+    }
+}
+
+impl Error for ButtonParseError {}
 
 /// Lists all possible buttons which can be sent in the event.
 #[derive(PartialEq, Eq, Debug)]

--- a/src/button_event.rs
+++ b/src/button_event.rs
@@ -5,7 +5,7 @@ use core::error::Error;
 use core::fmt::{Display, Formatter};
 
 /// Errors which can be raised while parsing a button event.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ButtonParseError {
     /// The message contained an unknown button. For the known buttons see [`Button`].
@@ -27,7 +27,7 @@ impl Display for ButtonParseError {
 impl Error for ButtonParseError {}
 
 /// Lists all possible buttons which can be sent in the event.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)] // the names are already obvious enough
 pub enum Button {
@@ -59,7 +59,7 @@ impl Button {
 }
 
 /// The state of the button.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough
@@ -80,7 +80,7 @@ impl ButtonState {
 }
 
 /// Represents a button event from the protocol.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)] // the names are already obvious enough
 pub struct ButtonEvent {

--- a/src/color_event.rs
+++ b/src/color_event.rs
@@ -5,7 +5,7 @@ use super::ProtocolParseError;
 use rgb::RGB8;
 
 /// Represents a color event from the protocol.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough

--- a/src/gyro_event.rs
+++ b/src/gyro_event.rs
@@ -3,7 +3,7 @@
 use super::{try_f32_from_le_bytes, ProtocolParseError};
 
 /// Represents a gyro event from the protocol.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@
 )))]
 compile_error!("at least one event type must be selected in the features!");
 
-#[cfg(not(any(feature = "use_alloc", feature = "use_heapless")))]
-compile_error!("you must choose either 'use_alloc' or 'use_heapless' as a feature!");
+#[cfg(not(any(feature = "alloc", feature = "heapless")))]
+compile_error!("you must choose either 'alloc' or 'heapless' as a feature!");
 
-#[cfg(all(feature = "use_alloc", feature = "use_heapless"))]
-compile_error!("you must choose either 'use_alloc' or 'use_heapless' as a feature but not both!");
+#[cfg(all(feature = "alloc", feature = "heapless"))]
+compile_error!("you must choose either 'alloc' or 'heapless' as a feature but not both!");
 
 #[cfg(feature = "accelerometer_event")]
 pub mod accelerometer_event;
@@ -59,12 +59,12 @@ use color_event::ColorEvent;
 use core::cmp::min;
 #[cfg(feature = "gyro_event")]
 use gyro_event::GyroEvent;
-#[cfg(feature = "use_heapless")]
+#[cfg(feature = "heapless")]
 use heapless::Vec;
 
-#[cfg(feature = "use_alloc")]
+#[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "use_alloc")]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::error::Error;
 use core::fmt::{Display, Formatter};
@@ -207,17 +207,17 @@ impl TryFrom<u8> for ControllerDataPackageType {
     }
 }
 
-#[cfg(feature = "use_heapless")]
+#[cfg(feature = "heapless")]
 type ParseResult<const MAX_RESULTS: usize> =
     Vec<Result<ControllerEvent, ProtocolParseError>, MAX_RESULTS>;
 
-#[cfg(feature = "use_alloc")]
+#[cfg(feature = "alloc")]
 type ParseResult<const MAX_RESULTS: usize> = Vec<Result<ControllerEvent, ProtocolParseError>>;
-#[cfg(feature = "use_alloc")]
+#[cfg(feature = "alloc")]
 const MAX_RESULTS: usize = 0;
 
 /// Parse the input string for commands. Unexpected content will be ignored if it's not formatted like a command!
-pub fn parse<#[cfg(feature = "use_heapless")] const MAX_RESULTS: usize>(
+pub fn parse<#[cfg(feature = "heapless")] const MAX_RESULTS: usize>(
     input: &[u8],
 ) -> ParseResult<MAX_RESULTS> {
     /// Simple state machine for the parser, represents whether the parser is seeking a start or has found it.
@@ -239,11 +239,11 @@ pub fn parse<#[cfg(feature = "use_heapless")] const MAX_RESULTS: usize>(
             }
             ParserState::ParseCommand => {
                 let data_package = extract_and_parse_command(&input[(pos - 1)..]);
-                #[cfg(feature = "use_alloc")]
+                #[cfg(feature = "alloc")]
                 result.push(data_package);
-                #[cfg(feature = "use_heapless")]
+                #[cfg(feature = "heapless")]
                 result.push(data_package).ok();
-                #[cfg(feature = "use_heapless")]
+                #[cfg(feature = "heapless")]
                 if result.len() == MAX_RESULTS {
                     return result;
                 }
@@ -399,9 +399,9 @@ mod tests {
     #[test]
     fn test_parse() {
         let input = b"\x00!B11:!B10;\x00\x00!\x00\x00\x00\x00!B138";
-        #[cfg(feature = "use_heapless")]
+        #[cfg(feature = "heapless")]
         let result = parse::<4>(input);
-        #[cfg(feature = "use_alloc")]
+        #[cfg(feature = "alloc")]
         let result = parse(input);
 
         assert_eq!(result.len(), 4);
@@ -413,7 +413,7 @@ mod tests {
                 e,
                 &ProtocolParseError::ButtonParseError(ButtonParseError::UnknownButtonState(b'3'))
             );
-            #[cfg(feature = "use_alloc")]
+            #[cfg(feature = "alloc")]
             {
                 use alloc::string::ToString;
                 use core::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ use magnetometer_event::MagnetometerEvent;
 use quaternion_event::QuaternionEvent;
 
 /// Lists all (supported) events which can be sent by the controller. These come with the parsed event data and are the result of a [`parse`] call.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)] // the names are already obvious enough
 pub enum ControllerEvent {
@@ -97,7 +97,7 @@ pub enum ControllerEvent {
 }
 
 /// Represents the different kinds of errors which can happen when the protocol is being parsed.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ProtocolParseError {
     /// The message contained an event which is not known to the current implementation.
@@ -157,7 +157,7 @@ impl Error for ProtocolParseError {
 }
 
 /// Lists all data packages which can be sent by the controller. Internal state used during parsing. Use [`ControllerEvent`] to return the actual event.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)] // the names are already obvious enough
 pub enum ControllerDataPackageType {

--- a/src/location_event.rs
+++ b/src/location_event.rs
@@ -3,7 +3,7 @@
 use super::{try_f32_from_le_bytes, ProtocolParseError};
 
 /// Represents a location event from the protocol.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough

--- a/src/magnetometer_event.rs
+++ b/src/magnetometer_event.rs
@@ -3,7 +3,7 @@
 use super::{try_f32_from_le_bytes, ProtocolParseError};
 
 /// Represents a magnetometer event from the protocol.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough

--- a/src/quaternion_event.rs
+++ b/src/quaternion_event.rs
@@ -3,7 +3,7 @@
 use super::{try_f32_from_le_bytes, ProtocolParseError};
 
 /// Represents a [quaternion](https://en.wikipedia.org/wiki/Quaternion) event from the protocol.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)] // the names are already obvious enough


### PR DESCRIPTION
see the individual commit messages for further details.

this is one step towards an eventual v1.0 release, the only missing thing after this will be stable dependencies (see #25)