### PR TITLE
CI: install `cargo-audit`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt clippy
       - name: Install required cargo components
-        run: cargo +stable install clippy-sarif sarif-fmt
+        run: cargo +stable install cargo-audit clippy-sarif sarif-fmt
       - name: build
         run: cargo build ${{ matrix.features }}
       - name: check
@@ -54,7 +54,7 @@ jobs:
           targets: thumbv7em-none-eabihf
           components: rustfmt clippy
       - name: Install required cargo components
-        run: cargo install clippy-sarif sarif-fmt flip-link
+        run: cargo install cargo-audit clippy-sarif sarif-fmt flip-link
       - name: build
         run: cargo build
         working-directory: examples/stm32f4-event-printer


### PR DESCRIPTION
GitHub recently changed the runners default image from Ubuntu 22.04 to 24.04 and in the process also changed the list of installed software. it seems, that `cargo-audit` is no longer installed by default. thus we now have to explicitly install it.