### PR TITLE
CI: use more generic version of `build-results`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,11 +88,12 @@ jobs:
     name: Final Results
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [lib, stm32f4-event-printer]
+    needs:
+      - lib
+      - stm32f4-event-printer
     steps:
-      - name: check for failed builds of the library
-        if: ${{ needs.lib.result != 'success' }}
-        run: exit 1
-      - name: check for failed builds of the example
-        if: ${{ needs.stm32f4-event-printer.result != 'success' }}
-        run: exit 1
+      - name: "check for failed builds"
+        run: |
+          cat <<EOF | jq -e 'unique | all(. == "success")'
+          ${{ toJson(needs.*.result) }}
+          EOF


### PR DESCRIPTION
this way only the `needs` list needs to be adapted and the step is fully generic. i wasn't aware of this trick when i first wrote `build-results`.